### PR TITLE
Поиск по произвольному запросу и кэширование результатов API HH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,5 @@ venv.bak/
 .mypy_cache/
 
 src/id_list.dat
+src/cache/**/*
+!src/cache/.gitkeep


### PR DESCRIPTION
Добавил поиск по прозивольному запросу:
```
$ python3 hh_research 'Python разработчик'
```

Все вакансии, полученные из API HH, сохраняются в папке cache. Если кэш с результатами определенного запроса надо обновить, нужно запустить скрипт с параметром `--refresh`.

```
$ python3 hh_research 'Python разработчик' --refresh
```
