### PR TITLE
Новый параметр для запроса - professional_role, фиксы

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ optional arguments:
   "options": {
     "text": "Data Scientist",
     "area": 1,
-    "per_page": 50
+    "per_page": 50,
+    "professional_roles": [96, 10]
   },
   "refresh": false,
   "max_workers": 7,
@@ -71,6 +72,8 @@ optional arguments:
 - `area` - локация поискового запроса (пример: `{area: 1}` - Москва),
 - `text` - поисковой запрос для вакансий (пример: `{text : Machine Learning}` или `{text: Java}`),
 - `per_page` - количество вакансий на страницу, по умолчанию **50**.
+- `professional_roles` - фильтр по роли в запросе ([возможные значения](https://api.hh.ru/openapi/redoc#tag/Obshie-spravochniki/paths/~1professional_roles/get))
+
 и другие параметры (в зависимости от требуемого запроса).
 
 Пример графика распределения зарплат:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ tqdm==4.45.0
 
 ### Command line arguments
 ```bash
-usage: parser.py [-h] [--text TEXT] [--max_workers MAX_WORKERS] [--refresh] [--save_result] [--update]
+usage: researcher.py [-h] [--text TEXT] [--max_workers MAX_WORKERS] [--refresh] [--save_result] [--update]
 
 HeadHunter (hh.ru) vacancies researcher
 

--- a/README.md
+++ b/README.md
@@ -33,14 +33,15 @@ tqdm==4.45.0
 
 ### Command line arguments
 ```bash
-usage: researcher.py [-h] [--text TEXT] [--max_workers MAX_WORKERS] [--refresh] [--save_result] [--update]
+usage: researcher.py [-h] [--text TEXT] [--professional_roles ROLE1 ROLE2 ...] [--max_workers MAX_WORKERS] [--refresh] [--save_result] [--update]
 
 HeadHunter (hh.ru) vacancies researcher
 
 optional arguments:
   -h, --help            show this help message and exit
   --text TEXT           Search query text (e.g. "Machine learning")
-  --max_workers MAX_WORKERS
+  --professional_roles  Professional role filter (Possible roles can be found here https://api.hh.ru/professional_roles)
+  --max_workers         MAX_WORKERS
                         Number of workers for multithreading.
   --refresh             Refresh cached data from HH API
   --save_result         Save parsed result as DataFrame to CSV file.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ requests==2.23.0
 scikit-learn==0.23.2
 scikit_learn==0.23.2
 scipy==1.5.3
-seaborn==0.10.0
+seaborn==0.11.0
 tqdm==4.45.0

--- a/settings.json
+++ b/settings.json
@@ -2,7 +2,8 @@
   "options": {
     "text": "Data Scientist",
     "area": 1,
-    "per_page": 50
+    "per_page": 50,
+    "professional_roles": [96, 10]
   },
   "refresh": false,
   "max_workers": 7,

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -201,6 +201,7 @@ class Analyzer:
         plt.xlabel("Salary x 1000 [RUB]")
         plt.yticks([], [])
         plt.tight_layout()
+        plt.show()
 
 
 if __name__ == "__main__":

--- a/src/data_collector.py
+++ b/src/data_collector.py
@@ -128,6 +128,17 @@ class DataCollector:
             self.clean_tags(vacancy["description"]),
         )
 
+    @staticmethod
+    def __encode_query_for_url(query: Optional[Dict]) -> str:
+        if 'professional_roles' in query:
+            query_copy = query.copy()
+
+            roles = '&'.join([f'professional_role={r}' for r in query_copy.pop('professional_roles')])
+
+            return roles + (f'&{urlencode(query_copy)}' if len(query_copy) > 0 else '')
+
+        return urlencode(query)
+
     def collect_vacancies(self, query: Optional[Dict], refresh: bool = False, max_workers: int = 1) -> Dict:
         """Parse vacancy JSON: get vacancy name, salary, experience etc.
 
@@ -148,6 +159,7 @@ class DataCollector:
         """
 
         # Get cached data if exists...
+        print(f'[INFO]: query to parse {query}')
         cache_name: str = query.get("text")
         cache_hash = hashlib.md5(cache_name.encode()).hexdigest()
         cache_file = os.path.join(CACHE_DIR, cache_hash)
@@ -159,7 +171,7 @@ class DataCollector:
             pass
 
         # Check number of pages...
-        target_url = self.__API_BASE_URL + "?" + urlencode(query)
+        target_url = self.__API_BASE_URL + "?" + self.__encode_query_for_url(query)
         num_pages = requests.get(target_url).json()["pages"]
 
         # Collect vacancy IDs...

--- a/src/data_collector.py
+++ b/src/data_collector.py
@@ -158,9 +158,10 @@ class DataCollector:
 
         """
 
+        url_params = self.__encode_query_for_url(query)
+
         # Get cached data if exists...
-        print(f'[INFO]: query to parse {query}')
-        cache_name: str = query.get("text")
+        cache_name: str = url_params
         cache_hash = hashlib.md5(cache_name.encode()).hexdigest()
         cache_file = os.path.join(CACHE_DIR, cache_hash)
         try:
@@ -171,7 +172,7 @@ class DataCollector:
             pass
 
         # Check number of pages...
-        target_url = self.__API_BASE_URL + "?" + self.__encode_query_for_url(query)
+        target_url = self.__API_BASE_URL + "?" + url_params
         num_pages = requests.get(target_url).json()["pages"]
 
         # Collect vacancy IDs...

--- a/src/parser.py
+++ b/src/parser.py
@@ -140,6 +140,11 @@ class Settings:
             "--text", action="store", type=str, default=None, help='Search query text (e.g. "Machine learning")',
         )
         parser.add_argument(
+            "--professional_roles", action="store", type=int, default=None,
+            help='Professional role filter (Possible roles can be found here https://api.hh.ru/professional_roles)',
+            nargs='*'
+        )
+        parser.add_argument(
             "--max_workers", action="store", type=int, default=None, help="Number of workers for multithreading.",
         )
         parser.add_argument(


### PR DESCRIPTION
Обновления:
1. Добавлен параметр professional_role при запросе к API HH для фильтрации по специальности
2. Имя хэша теперь генерируется на основе всех свойств `query`
3. Изменена версия `seaborn` на 0.11.0, так как на 0.10.0 нет функции `histplot`
4. Исправлена опечатка в README (`parser` вместо `researcher`)